### PR TITLE
Update uv guide paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,6 @@ Run these commands before committing changes:
 
 ```bash
 uv run python -m pytest -q
-uv run ruff check luca_paciolai
+uvx ruff check luca_paciolai
 uv run mypy luca_paciolai  # optional; may fail due to missing stubs
 ```

--- a/agentinstructs/setup.md
+++ b/agentinstructs/setup.md
@@ -32,28 +32,27 @@ if [ ! -f pyproject.toml ]; then
 fi
 
 # Sync dependencies
-echo "🔄 Syncing dependencies..."
-uv sync
+echo "🔄 Syncing dependencies with development extras..."
+uv sync --dev
 
-# Install dev tooling
-echo "🧰 Installing dev tools: mypy, ruff, rich, pre-commit, pytest, pytest-cov..."
-uv pip install mypy ruff rich pre-commit pytest pytest-cov
+# Dev tooling runs via uvx; no installation needed
 
 # Pre-commit hook setup (if available)
 if [ -f .pre-commit-config.yaml ]; then
   echo "⚙️  Installing pre-commit hooks..."
-  pre-commit install
+  uvx pre-commit install
 fi
 
 # Run static checks
 echo "🧪 Running static checks..."
-ruff check luca_paciolai || true
-mypy luca_paciolai || true
+uvx ruff check luca_paciolai || true
+uv run mypy luca_paciolai || true
 
 # Run tests if available
 if [ -d tests ]; then
   echo "🧪 Running tests..."
-  uv run python -m pytest -q --cov=luca_paciolai --cov-report=term-missing
+  uv run --with pytest-cov python -m pytest -q \
+    --cov=luca_paciolai --cov-report=term-missing
 else
   echo "⚠️  No tests directory found. Skipping tests."
 fi

--- a/agentinstructs/uv.md
+++ b/agentinstructs/uv.md
@@ -170,9 +170,9 @@ Use `uvx` (alias for `uv tool run`) to run tools in isolated environments:
 ```bash
 # Run tools without installation
 uvx ruff check .
-uvx black src/
+uvx black luca_paciolai/
 uvx pytest
-uvx mypy src/
+uvx mypy luca_paciolai/
 
 # Run specific version
 uvx ruff@0.3.0 check .
@@ -334,13 +334,13 @@ WORKDIR /app
 
 # Copy project files
 COPY pyproject.toml uv.lock ./
-COPY src/ ./src/
+COPY luca_paciolai/ ./luca_paciolai/
 
 # Install dependencies
 RUN uv sync --locked --no-editable
 
 # Run application
-CMD ["/app/.venv/bin/python", "-m", "src.main"]
+CMD ["/app/.venv/bin/python", "main.py"]
 ```
 
 ### GitHub Actions Integration
@@ -412,7 +412,7 @@ uv run pytest
 
 # For tools, use uvx
 uvx ruff check .
-uvx black src/
+uvx black luca_paciolai/
 ```
 
 ### 4. Environment Synchronization
@@ -438,13 +438,13 @@ Use uvx for ephemeral tool execution:
 # Linting and formatting
 uvx ruff check .
 uvx ruff format .
-uvx black src/
+uvx black luca_paciolai/
 
 # Type checking
-uvx mypy src/
+uvx mypy luca_paciolai/
 
 # Security scanning
-uvx bandit -r src/
+uvx bandit -r luca_paciolai/
 ```
 
 ## Migration from Other Tools
@@ -492,7 +492,7 @@ uv sync --dev
 # 3. Test and lint
 uv run pytest
 uvx ruff check .
-uvx black src/
+uvx black luca_paciolai/
 
 # 4. Add new dependency
 uv add new-package
@@ -513,11 +513,11 @@ uv sync --locked --dev
 
 # Run quality checks
 uvx ruff check .
-uvx black --check src/
-uv run mypy src/
+uvx black --check luca_paciolai/
+uv run mypy luca_paciolai/
 
 # Run tests
-uv run pytest --cov=src
+uv run pytest --cov=luca_paciolai
 
 # Build package
 uv build


### PR DESCRIPTION
## Summary
- revise uv instructions to use `luca_paciolai` paths instead of `src`
- clarify Docker example to call `main.py`

## Testing
- `uv run python -m pytest -q`
- `uvx ruff check luca_paciolai`
- `uv run mypy luca_paciolai` *(fails: missing stubs)*

------
https://chatgpt.com/codex/tasks/task_e_6854ce338810832badb726cf519287a7