### PR TITLE
Fix mypy errors by ignoring missing imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,7 @@ dev = [
 [tool.setuptools]
 packages = ["luca_paciolai"]
 
+[tool.mypy]
+python_version = "3.12"
+ignore_missing_imports = true
+


### PR DESCRIPTION
## Summary
- configure mypy to ignore missing imports so the setup script passes without errors

## Testing
- `uvx ruff check luca_paciolai`
- `uv run mypy luca_paciolai`
- `uv run --with pytest-cov python -m pytest -q --cov=luca_paciolai --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_6854d25b9824832b9d3f551c5006e75b