### PR TITLE
Remove README dependency guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,3 @@ Run the test suite with:
 uv run python -m pytest -q
 ```
 
-## Adding dependencies
-
-Use `uv add` to manage new packages and update your lockfile. After adding, run `uv sync` to install them:
-
-```bash
-uv add typer
-uv sync
-```


### PR DESCRIPTION
## Summary
- drop the "Adding dependencies" section from the README since uv add workflow is established

## Testing
- `uv run python -m pytest -q`
- `uvx ruff check luca_paciolai`
- `uv run mypy luca_paciolai` *(fails: Unexpected keyword argument "table" for `__init_subclass__`)*

------
https://chatgpt.com/codex/tasks/task_e_6854d59ea63c832b99955948f8a71d3b