### PR TITLE
Extend Transaction model fields

### DIFF
--- a/agentinstructs/SPEC.md
+++ b/agentinstructs/SPEC.md
@@ -70,6 +70,7 @@ It interprets the statement via LLM and converts it into a structured, double-en
 
 ```json
 {
+  "id": 1,
   "date": "YYYY-MM-DD",
   "description": "string",
   "debit": "Expenses:Coffee",
@@ -78,14 +79,24 @@ It interprets the statement via LLM and converts it into a structured, double-en
   "currency": "USD",
   "instrument": null,
   "quantity": null,
-  "price": null,
-  "lot_id": null
+  "unit_price": null,
+  "lot_id": null,
+  "fee_amount": null,
+  "fee_currency": null,
+  "fee_account": null,
+  "memo": null,
+  "reference_number": null,
+  "vendor": null,
+  "payment_method": null,
+  "tax_amount": null,
+  "tax_rate": null,
+  "reconciled": null
 }
 ```
 
 Fields:
 
-* `instrument`, `quantity`, `price`: only required for investment transactions.
+* `instrument`, `quantity`, `unit_price`: only required for investment transactions.
 * `lot_id`: must be generated or matched when an investment is recorded.
 
 ---
@@ -97,6 +108,7 @@ Fields:
 ```python
 @dataclass
 class Transaction:
+    id: int
     date: date
     description: str
     debit: str
@@ -105,8 +117,18 @@ class Transaction:
     currency: str
     instrument: Optional[str] = None
     quantity: Optional[float] = None
-    price: Optional[float] = None
+    unit_price: Optional[float] = None
     lot_id: Optional[str] = None
+    fee_amount: Optional[float] = None
+    fee_currency: Optional[str] = None
+    fee_account: Optional[str] = None
+    memo: Optional[str] = None
+    reference_number: Optional[str] = None
+    vendor: Optional[str] = None
+    payment_method: Optional[str] = None
+    tax_amount: Optional[float] = None
+    tax_rate: Optional[float] = None
+    reconciled: Optional[bool] = None
 ```
 
 ### TaxLot

--- a/luca_paciolai/llm.py
+++ b/luca_paciolai/llm.py
@@ -7,6 +7,7 @@ from typing import Dict
 
 
 SCHEMA = {
+    "id": None,
     "date": "YYYY-MM-DD",
     "description": "string",
     "debit": "Expenses:Coffee",
@@ -15,8 +16,18 @@ SCHEMA = {
     "currency": "USD",
     "instrument": None,
     "quantity": None,
-    "price": None,
+    "unit_price": None,
     "lot_id": None,
+    "fee_amount": None,
+    "fee_currency": None,
+    "fee_account": None,
+    "memo": None,
+    "reference_number": None,
+    "vendor": None,
+    "payment_method": None,
+    "tax_amount": None,
+    "tax_rate": None,
+    "reconciled": None,
 }
 
 
@@ -32,6 +43,7 @@ def parse_transaction(text: str, accounts: list[str]) -> Dict:
     """Naively parse a transaction statement without network access."""
     amount = _extract_amount(text)
     return {
+        "id": None,
         "date": date.today(),
         "description": text,
         "debit": "Expenses:Coffee",
@@ -40,6 +52,16 @@ def parse_transaction(text: str, accounts: list[str]) -> Dict:
         "currency": "USD",
         "instrument": None,
         "quantity": None,
-        "price": None,
+        "unit_price": None,
         "lot_id": None,
+        "fee_amount": None,
+        "fee_currency": None,
+        "fee_account": None,
+        "memo": None,
+        "reference_number": None,
+        "vendor": None,
+        "payment_method": None,
+        "tax_amount": None,
+        "tax_rate": None,
+        "reconciled": None,
     }

--- a/luca_paciolai/models.py
+++ b/luca_paciolai/models.py
@@ -16,8 +16,18 @@ class Transaction(SQLModel, table=True):
     currency: str
     instrument: Optional[str] = None
     quantity: Optional[float] = None
-    price: Optional[float] = None
+    unit_price: Optional[float] = None
     lot_id: Optional[str] = None
+    fee_amount: Optional[float] = None
+    fee_currency: Optional[str] = None
+    fee_account: Optional[str] = None
+    memo: Optional[str] = None
+    reference_number: Optional[str] = None
+    vendor: Optional[str] = None
+    payment_method: Optional[str] = None
+    tax_amount: Optional[float] = None
+    tax_rate: Optional[float] = None
+    reconciled: Optional[bool] = None
 
 
 class TaxLot(SQLModel, table=True):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,8 @@ def test_transaction_creation() -> None:
         credit="Assets:Cash",
         amount=6.0,
         currency="USD",
+        memo="morning run",
+        fee_amount=0.5,
     )
     assert tx.amount == 6.0
 


### PR DESCRIPTION
## Summary
- expand `Transaction` dataclass with optional metadata fields
- reflect new fields in parsing logic and spec
- update tests for new attributes

## Testing
- `uv run python -m pytest -q`
- `uvx ruff check luca_paciolai`
- `uv run mypy luca_paciolai` *(fails: Unexpected keyword argument "table")*

------
https://chatgpt.com/codex/tasks/task_e_6854d9145d04832bb3b6bc9b442c3ef8