### PR TITLE
Add Venice model selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ A command-line double-entry accounting system powered by an LLM. The tool parses
 uv run main.py "I bought coffee today for $6"
 ```
 
+Select a Venice model for LLM parsing:
+
+```bash
+uv run main.py select-model
+```
+
 Run the test suite with:
 
 ```bash

--- a/luca_paciolai/cli.py
+++ b/luca_paciolai/cli.py
@@ -9,6 +9,11 @@ import typer
 from .ledger import init_db, add_transaction
 from .llm import parse_transaction
 from .models import Transaction
+from .model_selection import (
+    fetch_venice_models,
+    load_selected_model,
+    save_selected_model,
+)
 
 app = typer.Typer()
 DB_PATH = Path("ledger.db")
@@ -19,10 +24,31 @@ def add(text: str) -> None:
     """Parse natural language transaction and save to the ledger."""
     session = init_db(f"sqlite:///{DB_PATH}")
     # TODO: load existing accounts
+    _model = load_selected_model()
+    # TODO: pass `_model` to the LLM API when implemented
     result = parse_transaction(text, [])
     tx = Transaction(**result)
     add_transaction(session, tx)
     typer.echo(json.dumps(result, indent=2, default=str))
+
+
+@app.command()
+def select_model() -> None:
+    """Choose and persist a Venice model for LLM parsing."""
+    models = fetch_venice_models()
+    if not models:
+        typer.echo("No compatible models found.")
+        raise typer.Exit(code=1)
+    for idx, model in enumerate(models, start=1):
+        name = model["model_spec"]["name"]
+        typer.echo(f"{idx}. {name} ({model['id']})")
+    choice = typer.prompt("Enter model number", type=int)
+    if choice < 1 or choice > len(models):
+        typer.echo("Invalid selection.")
+        raise typer.Exit(code=1)
+    selected = models[choice - 1]["id"]
+    save_selected_model(selected)
+    typer.echo(f"Selected model: {selected}")
 
 
 def main() -> None:

--- a/luca_paciolai/model_selection.py
+++ b/luca_paciolai/model_selection.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import requests
+
+CONFIG_PATH = Path("model.json")
+
+
+def fetch_venice_models() -> List[Dict[str, Any]]:
+    """Return Venice models that support reasoning."""
+    url = "https://api.venice.ai/api/v1/models?type=text"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    data = response.json().get("data", [])
+    return [
+        m
+        for m in data
+        if m.get("model_spec", {})
+        .get("capabilities", {})
+        .get("supportsReasoning")
+    ]
+
+
+def save_selected_model(model_id: str) -> None:
+    """Persist the chosen model ID."""
+    CONFIG_PATH.write_text(json.dumps({"model": model_id}))
+
+
+def load_selected_model() -> str | None:
+    """Return the currently selected model ID if stored."""
+    if CONFIG_PATH.exists():
+        return json.loads(CONFIG_PATH.read_text()).get("model")
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "pydantic>=2.11.7",
     "sqlmodel>=0.0.24",
     "typer>=0.16.0",
+    "requests>=2.31.0",
 ]
 
 [dependency-groups]

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from typing import Any, Dict
+
+import requests
+
+from luca_paciolai import model_selection
+
+
+def test_fetch_venice_models_filters(monkeypatch):
+    sample: Dict[str, Any] = {
+        "data": [
+            {
+                "id": "a",
+                "model_spec": {"capabilities": {"supportsReasoning": True}},
+            },
+            {
+                "id": "b",
+                "model_spec": {"capabilities": {"supportsReasoning": False}},
+            },
+        ]
+    }
+
+    class Resp:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> Dict[str, Any]:
+            return sample
+
+    def fake_get(url: str, timeout: int = 10) -> Resp:  # type: ignore[override]
+        return Resp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    models = model_selection.fetch_venice_models()
+    assert [m["id"] for m in models] == ["a"]
+
+
+def test_save_and_load_selected_model(tmp_path: Path, monkeypatch):
+    path = tmp_path / "model.json"
+    monkeypatch.setattr(model_selection, "CONFIG_PATH", path)
+    model_selection.save_selected_model("foo")
+    assert model_selection.load_selected_model() == "foo"


### PR DESCRIPTION
## Summary
- introduce `model_selection` module for Venice API integration
- add `select-model` command to choose Venice LLM model
- document new CLI command
- include dependency for `requests`
- test model filtering and persistence

## Testing
- `uvx ruff check luca_paciolai`
- `uv run python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e38479e4832bbc0d1eeef8ad2401