### PR TITLE
Remove local LLM parser

### DIFF
--- a/luca_paciolai/models.py
+++ b/luca_paciolai/models.py
@@ -5,7 +5,7 @@ from sqlmodel import Field, SQLModel
 
 __all__ = ["Transaction", "TaxLot"]
 
-class Transaction(SQLModel, table=True):
+class Transaction(SQLModel, table=True):  # type: ignore[call-arg]
     """A double-entry journal entry."""
     id: Optional[int] = Field(default=None, primary_key=True)
     date: date
@@ -20,7 +20,7 @@ class Transaction(SQLModel, table=True):
     lot_id: Optional[str] = None
 
 
-class TaxLot(SQLModel, table=True):
+class TaxLot(SQLModel, table=True):  # type: ignore[call-arg]
     """Represents an investment acquisition lot."""
     id: Optional[int] = Field(default=None, primary_key=True)
     lot_id: str

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,6 +1,50 @@
 from luca_paciolai.llm import parse_transaction
 
 
-def test_parse_transaction_amount() -> None:
-    result = parse_transaction("I bought 2 coffees for 10 dollars", [])
-    assert result["amount"] == 10.0
+def test_parse_transaction_requires_key() -> None:
+    """Calling ``parse_transaction`` without an API key should fail."""
+
+    import pytest
+
+    with pytest.raises(RuntimeError):
+        parse_transaction("I bought coffee for 10 dollars", [])
+
+
+def test_parse_transaction_venice(monkeypatch) -> None:
+    """Ensure API code path is exercised when VENICE_API_KEY is set."""
+
+    import json
+    from types import SimpleNamespace
+    import openai
+
+    expected = {
+        "date": "2024-01-01",
+        "description": "Coffee",
+        "debit": "Expenses:Coffee",
+        "credit": "Assets:Cash",
+        "amount": 10.0,
+        "currency": "USD",
+        "instrument": None,
+        "quantity": None,
+        "price": None,
+        "lot_id": None,
+    }
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=json.dumps(expected))
+                    )
+                ]
+            )
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setattr(openai, "OpenAI", FakeClient)
+    monkeypatch.setenv("VENICE_API_KEY", "test-key")
+    result = parse_transaction("I bought coffee for 10 dollars", [])
+    assert result == expected


### PR DESCRIPTION
## Summary
- drop regex fallback for parsing transactions
- require VENICE_API_KEY environment variable
- adjust llm tests for API-only behavior
- ignore mypy error for `SQLModel(..., table=True)`

## Testing
- `uvx ruff check luca_paciolai tests`
- `uv run mypy luca_paciolai`
- `uv run python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854e299e844832bb19f1c414af63d4f