### PR TITLE
Remove local LLM parser

### DIFF
--- a/luca_paciolai/llm.py
+++ b/luca_paciolai/llm.py
@@ -1,9 +1,11 @@
-"""Simple natural language parser for transactions."""
+"""Parse transactions via the Venice.ai API."""
 from __future__ import annotations
 
-import re
-from datetime import date
+import json
+import os
 from typing import Dict
+
+import openai
 
 
 SCHEMA = {
@@ -20,26 +22,57 @@ SCHEMA = {
 }
 
 
-def _extract_amount(text: str) -> float:
-    """Return the first dollar amount mentioned in ``text``."""
-    match = re.search(r"\$?(\d+(?:\.\d+)?)\s*dollars", text, re.IGNORECASE)
-    if match:
-        return float(match.group(1))
-    return 0.0
+VENICE_BASE_URL = os.getenv("VENICE_BASE_URL", "https://api.venice.ai/api/v1")
+"""Base URL for the Venice.ai API."""
+
+VENICE_MODELS = {
+    "qwen3-4b": "Venice Small",
+    "mistral-31-24b": "Venice Medium",
+    "qwen3-235b": "Venice Large",
+    "llama-3.2-3b": "Llama 3.2 3B",
+    "llama-3.3-70b": "Llama 3.3 70B",
+}
+"""Allowed model identifiers mapped to human-friendly names."""
+
+
+def _call_venice(text: str, accounts: list[str], api_key: str) -> Dict:
+    """Call the Venice ``/chat/completions`` endpoint and return parsed JSON."""
+
+    client = openai.OpenAI(api_key=api_key, base_url=VENICE_BASE_URL)
+
+    system = (
+        "You are a bookkeeping assistant. Parse the user transaction into the "
+        "following JSON schema: " + json.dumps(SCHEMA)
+    )
+    if accounts:
+        system += " Available accounts: " + ", ".join(accounts) + "."
+
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": text},
+    ]
+
+    model = os.getenv("VENICE_MODEL", "qwen3-4b")
+    if model not in VENICE_MODELS:
+        raise RuntimeError(f"Unsupported VENICE_MODEL: {model}")
+
+    response = client.chat.completions.create(
+        model=model,
+        messages=messages,
+        response_format={"type": "json_object"},
+    )
+    content = response.choices[0].message.content
+    return json.loads(content)
 
 
 def parse_transaction(text: str, accounts: list[str]) -> Dict:
-    """Naively parse a transaction statement without network access."""
-    amount = _extract_amount(text)
-    return {
-        "date": date.today(),
-        "description": text,
-        "debit": "Expenses:Coffee",
-        "credit": "Assets:Cash",
-        "amount": amount,
-        "currency": "USD",
-        "instrument": None,
-        "quantity": None,
-        "price": None,
-        "lot_id": None,
-    }
+    """Parse ``text`` using the Venice API.
+
+    ``VENICE_API_KEY`` must be defined in the environment.
+    """
+
+    api_key = os.getenv("VENICE_API_KEY")
+    if not api_key:
+        raise RuntimeError("VENICE_API_KEY is not set")
+
+    return _call_venice(text, accounts, api_key)

--- a/luca_paciolai/models.py
+++ b/luca_paciolai/models.py
@@ -5,7 +5,7 @@ from sqlmodel import Field, SQLModel
 
 __all__ = ["Transaction", "TaxLot"]
 
-class Transaction(SQLModel, table=True):
+class Transaction(SQLModel, table=True):  # type: ignore[call-arg]
     """A double-entry journal entry."""
     id: Optional[int] = Field(default=None, primary_key=True)
     date: date
@@ -20,7 +20,7 @@ class Transaction(SQLModel, table=True):
     lot_id: Optional[str] = None
 
 
-class TaxLot(SQLModel, table=True):
+class TaxLot(SQLModel, table=True):  # type: ignore[call-arg]
     """Represents an investment acquisition lot."""
     id: Optional[int] = Field(default=None, primary_key=True)
     lot_id: str

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,6 +1,62 @@
 from luca_paciolai.llm import parse_transaction
 
 
-def test_parse_transaction_amount() -> None:
-    result = parse_transaction("I bought 2 coffees for 10 dollars", [])
-    assert result["amount"] == 10.0
+def test_parse_transaction_requires_key() -> None:
+    """Calling ``parse_transaction`` without an API key should fail."""
+
+    import pytest
+
+    with pytest.raises(RuntimeError):
+        parse_transaction("I bought coffee for 10 dollars", [])
+
+
+def test_parse_transaction_venice(monkeypatch) -> None:
+    """Ensure API code path is exercised when VENICE_API_KEY is set."""
+
+    import json
+    from types import SimpleNamespace
+    import openai
+
+    expected = {
+        "date": "2024-01-01",
+        "description": "Coffee",
+        "debit": "Expenses:Coffee",
+        "credit": "Assets:Cash",
+        "amount": 10.0,
+        "currency": "USD",
+        "instrument": None,
+        "quantity": None,
+        "price": None,
+        "lot_id": None,
+    }
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=json.dumps(expected))
+                    )
+                ]
+            )
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setattr(openai, "OpenAI", FakeClient)
+    monkeypatch.setenv("VENICE_API_KEY", "test-key")
+    result = parse_transaction("I bought coffee for 10 dollars", [])
+    assert result == expected
+
+
+def test_invalid_model(monkeypatch) -> None:
+    """An unsupported VENICE_MODEL should raise an error."""
+
+    monkeypatch.setenv("VENICE_API_KEY", "key")
+    monkeypatch.setenv("VENICE_MODEL", "bad-model")
+
+    import pytest
+
+    with pytest.raises(RuntimeError):
+        parse_transaction("hello", [])


### PR DESCRIPTION
## Summary
- drop regex fallback for parsing transactions
- require VENICE_API_KEY environment variable
- adjust llm tests for API-only behavior
- ignore mypy error for `SQLModel(..., table=True)`
- validate VENICE_MODEL against allowed models

## Testing
- `uvx ruff check luca_paciolai tests`
- `uv run mypy luca_paciolai`
- `uv run python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854e299e844832bb19f1c414af63d4f