### PR TITLE
Massive refactor across modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A command-line double-entry accounting system powered by an LLM. The tool parses
 uv run main.py add "I bought coffee today for $6"
 ```
 
+The ledger database path is configurable via ``luca_paciolai.config.LEDGER_PATH``.
+
 Select a Venice model for LLM parsing:
 
 ```bash

--- a/luca_paciolai/cli.py
+++ b/luca_paciolai/cli.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+
+__all__ = ["app", "main", "add", "select_model"]
 
 import typer
 
-from .ledger import init_db, add_transaction
+from .ledger import create_session, add_transaction
 from .llm import parse_transaction
 from .models import Transaction
 from .model_selection import (
@@ -16,13 +17,12 @@ from .model_selection import (
 )
 
 app = typer.Typer()
-DB_PATH = Path("ledger.db")
 
 
 @app.command()
 def add(text: str) -> None:
     """Parse natural language transaction and save to the ledger."""
-    session = init_db(f"sqlite:///{DB_PATH}")
+    session = create_session()
     # TODO: load existing accounts
     _model = load_selected_model()
     # TODO: pass `_model` to the LLM API when implemented

--- a/luca_paciolai/config.py
+++ b/luca_paciolai/config.py
@@ -1,0 +1,7 @@
+"""Shared configuration constants."""
+from pathlib import Path
+
+__all__ = ["LEDGER_PATH", "MODEL_CONFIG_PATH"]
+
+LEDGER_PATH = Path("ledger.db")
+MODEL_CONFIG_PATH = Path("model.json")

--- a/luca_paciolai/ledger.py
+++ b/luca_paciolai/ledger.py
@@ -4,14 +4,23 @@ from __future__ import annotations
 
 from sqlmodel import SQLModel, Session, create_engine
 
+from .config import LEDGER_PATH
+
 from .models import Transaction
 
+__all__ = ["create_session", "init_db", "add_transaction"]
 
-def init_db(db_url: str) -> Session:
-    """Initializes the SQLite database and returns a session."""
-    engine = create_engine(db_url, echo=False)
+
+def create_session(db_url: str | None = None) -> Session:
+    """Return a database session, creating tables on first use."""
+    url = f"sqlite:///{LEDGER_PATH}" if db_url is None else db_url
+    engine = create_engine(url, echo=False)
     SQLModel.metadata.create_all(engine)
     return Session(engine)
+
+
+# Backwards compatibility
+init_db = create_session
 
 
 def add_transaction(session: Session, tx: Transaction) -> None:

--- a/luca_paciolai/llm.py
+++ b/luca_paciolai/llm.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import re
 from datetime import date
-from typing import Dict
+from typing import Dict, Sequence, Any
+
+__all__ = ["parse_transaction", "extract_amount", "SCHEMA"]
 
 
 SCHEMA = {
@@ -31,17 +33,20 @@ SCHEMA = {
 }
 
 
-def _extract_amount(text: str) -> float:
+_AMOUNT_RE = re.compile(r"\$?(\d+(?:\.\d+)?)\s*dollars", re.IGNORECASE)
+
+
+def extract_amount(text: str) -> float:
     """Return the first dollar amount mentioned in ``text``."""
-    match = re.search(r"\$?(\d+(?:\.\d+)?)\s*dollars", text, re.IGNORECASE)
+    match = _AMOUNT_RE.search(text)
     if match:
         return float(match.group(1))
     return 0.0
 
 
-def parse_transaction(text: str, accounts: list[str]) -> Dict:
+def parse_transaction(text: str, accounts: Sequence[str]) -> Dict[str, Any]:
     """Naively parse a transaction statement without network access."""
-    amount = _extract_amount(text)
+    amount = extract_amount(text)
     return {
         "id": None,
         "date": date.today(),

--- a/luca_paciolai/model_selection.py
+++ b/luca_paciolai/model_selection.py
@@ -6,7 +6,16 @@ from typing import Any, Dict, List
 
 import requests
 
-CONFIG_PATH = Path("model.json")
+from .config import MODEL_CONFIG_PATH
+
+__all__ = [
+    "fetch_venice_models",
+    "save_selected_model",
+    "load_selected_model",
+    "CONFIG_PATH",
+]
+
+CONFIG_PATH = MODEL_CONFIG_PATH
 
 
 def fetch_venice_models() -> List[Dict[str, Any]]:
@@ -24,13 +33,15 @@ def fetch_venice_models() -> List[Dict[str, Any]]:
     ]
 
 
-def save_selected_model(model_id: str) -> None:
+def save_selected_model(model_id: str, path: Path | None = None) -> None:
     """Persist the chosen model ID."""
-    CONFIG_PATH.write_text(json.dumps({"model": model_id}))
+    cfg_path = CONFIG_PATH if path is None else path
+    cfg_path.write_text(json.dumps({"model": model_id}))
 
 
-def load_selected_model() -> str | None:
+def load_selected_model(path: Path | None = None) -> str | None:
     """Return the currently selected model ID if stored."""
-    if CONFIG_PATH.exists():
-        return json.loads(CONFIG_PATH.read_text()).get("model")
+    cfg_path = CONFIG_PATH if path is None else path
+    if cfg_path.exists():
+        return json.loads(cfg_path.read_text()).get("model")
     return None


### PR DESCRIPTION
## Summary
- introduce `config` module for central paths
- refactor ledger session handling
- clean up CLI imports and expose public API
- improve llm parsing helpers
- expose helpers in `model_selection`
- document ledger path configuration

## Testing
- `uvx ruff check luca_paciolai`
- `uv run python -m pytest -q`
- `uv run mypy luca_paciolai` *(fails: Library stubs not installed for "requests")*


------
https://chatgpt.com/codex/tasks/task_e_6854ec331a48832bb521b078c72e5ae8