### PR TITLE
Use OpenAI for transaction parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A command-line double-entry accounting system powered by an LLM. The tool parses
 uv run main.py add "I bought coffee today for $6"
 ```
 
+Set the `OPENAI_API_KEY` environment variable before running commands. The
+parser sends statements to OpenAI's API.
+
 The ledger database path is configurable via ``luca_paciolai.config.LEDGER_PATH``.
 
 Select a Venice model for LLM parsing:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,6 +1,21 @@
+from types import SimpleNamespace
+
+import openai
+
 from luca_paciolai.llm import parse_transaction
 
 
-def test_parse_transaction_amount() -> None:
+def test_parse_transaction_amount(monkeypatch) -> None:
+    class FakeClient:
+        def __init__(self) -> None:
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+        def create(self, *args, **kwargs):
+            resp = SimpleNamespace()
+            msg = SimpleNamespace(content='{"amount": 10.0}')
+            resp.choices = [SimpleNamespace(message=msg)]
+            return resp
+
+    monkeypatch.setattr(openai, "OpenAI", lambda: FakeClient())
     result = parse_transaction("I bought 2 coffees for 10 dollars", [])
     assert result["amount"] == 10.0


### PR DESCRIPTION
## Summary
- replace regex-based parser with OpenAI API call
- patch tests to stub OpenAI client
- mention OPENAI_API_KEY requirement in README

## Testing
- `uvx ruff check luca_paciolai tests`
- `uv run python -m pytest -q`
- `uv run mypy luca_paciolai` *(fails: Library stubs not installed for "requests")*

------
https://chatgpt.com/codex/tasks/task_e_6854ed848d10832b8bfdc7442e4da1de