### PR TITLE
Add Venice best practices guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 Refer to `agentinstructs/` for detailed usage instructions and the complete functional specification (`SPEC.md`).
+Additional Venice integration tips are documented in `agentinstructions/venice_best_practices.md`.
 
 ## Engineering Guide
 For an overview of the repository structure and module responsibilities, see

--- a/README.md
+++ b/README.md
@@ -20,3 +20,20 @@ Run the test suite with:
 uv run python -m pytest -q
 ```
 
+### Using the Venice API
+
+`luca_paciolai.venice_client` provides a helper for interacting with Venice's
+OpenAI-compatible API:
+
+```python
+from luca_paciolai.venice_client import create_client, chat_completion
+
+client = create_client("your-api-key")
+response = chat_completion(
+    client,
+    [{"role": "user", "content": "Why is the sky blue?"}],
+    include_venice_system_prompt=False,
+)
+print(response)
+```
+

--- a/agentinstructions/venice_best_practices.md
+++ b/agentinstructions/venice_best_practices.md
@@ -1,0 +1,40 @@
+# Venice API Best Practices
+
+This document summarizes recommendations for integrating with the Venice API using its OpenAI-compatible interface.
+
+## Base Configuration
+- Use the base URL `https://api.venice.ai/api/v1` for all API calls.
+- Configure your OpenAI client with this `base_url`.
+
+```python
+from openai import OpenAI
+
+client = OpenAI(api_key="YOUR_KEY", base_url="https://api.venice.ai/api/v1")
+```
+
+## Available Endpoints
+- `/api/v1/models` – list available models and their capabilities.
+- `/api/v1/chat/completions` – generate text responses.
+- `/api/v1/image/generations` – generate images from prompts.
+
+## System Prompts
+Venice automatically appends a default system prompt to your messages. To disable this behaviour pass `venice_parameters={"include_venice_system_prompt": False}` when creating a completion.
+
+```python
+client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Why is the sky blue?"}],
+    venice_parameters={"include_venice_system_prompt": False},
+)
+```
+
+## Best Practices
+- Implement robust error handling for API responses.
+- Be mindful of rate limits during the beta period.
+- Test both with and without the Venice system prompt enabled.
+- Keep your API keys secure and rotate them regularly.
+
+## Differences from OpenAI
+- Additional `venice_parameters` provide features not present in the OpenAI API.
+- Default system prompt handling differs.
+- Some model names may differ from those on OpenAI. Consult the Venice API docs for supported models.

--- a/luca_paciolai/venice_client.py
+++ b/luca_paciolai/venice_client.py
@@ -1,0 +1,37 @@
+"""Utility for interacting with Venice's OpenAI-compatible API."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List
+
+from openai import OpenAI, OpenAIError
+
+BASE_URL = "https://api.venice.ai/api/v1"
+
+
+def create_client(api_key: str | None = None) -> OpenAI:
+    """Return an OpenAI client configured for Venice."""
+    key = api_key or os.getenv("VENICE_API_KEY")
+    if not key:
+        raise ValueError("A Venice API key is required")
+    return OpenAI(api_key=key, base_url=BASE_URL)
+
+
+def chat_completion(
+    client: OpenAI,
+    messages: List[Dict[str, str]],
+    *,
+    model: str = "default",
+    include_venice_system_prompt: bool = True,
+) -> str:
+    """Request a chat completion from Venice with basic error handling."""
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=messages,
+            venice_parameters={"include_venice_system_prompt": include_venice_system_prompt},
+        )
+    except OpenAIError as exc:  # pragma: no cover - network failure
+        raise RuntimeError(f"Venice API error: {exc}") from exc
+    return resp.choices[0].message.content  # type: ignore[return-value]

--- a/tests/test_venice_client.py
+++ b/tests/test_venice_client.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict, List
+
+from luca_paciolai import venice_client
+
+
+def test_create_client_uses_base_url(monkeypatch):
+    captured: Dict[str, Any] = {}
+
+    class Dummy:
+        def __init__(self, api_key: str, base_url: str):
+            captured["api_key"] = api_key
+            captured["base_url"] = base_url
+
+    monkeypatch.setattr(venice_client, "OpenAI", Dummy)
+    venice_client.create_client("key")
+    assert captured["api_key"] == "key"
+    assert captured["base_url"] == venice_client.BASE_URL
+
+
+def test_chat_completion_passes_system_prompt(monkeypatch):
+    class Chat:
+        def __init__(self):
+            self.kwargs: Dict[str, Any] = {}
+
+        class Completions:
+            def __init__(self, parent: "Chat"):
+                self.parent = parent
+
+            def create(self, **kwargs: Any) -> Any:  # type: ignore[override]
+                self.parent.kwargs = kwargs
+                return type("Resp", (), {"choices": [type("M", (), {"message": type("Msg", (), {"content": "ok"})()})()]})()
+
+        @property
+        def completions(self) -> "Chat.Completions":
+            return Chat.Completions(self)
+
+    class Dummy:
+        def __init__(self):
+            self.chat = Chat()
+
+    client = Dummy()
+    venice_client.chat_completion(
+        client,
+        [{"role": "user", "content": "hi"}],
+        include_venice_system_prompt=False,
+    )
+    assert client.chat.kwargs["venice_parameters"] == {"include_venice_system_prompt": False}
+


### PR DESCRIPTION
## Summary
- document Venice API best practices at `agentinstructions/venice_best_practices.md`
- reference new guide in `AGENTS.md`

## Testing
- `uvx ruff check luca_paciolai`
- `uv run python -m pytest -q`
- `uv run mypy luca_paciolai` *(fails: Library stubs not installed for "requests")*

------
https://chatgpt.com/codex/tasks/task_e_6854ecc19318832b88076bc16ec01276