### PR TITLE
Add CLI add command test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,42 @@
+import json
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+from luca_paciolai import cli
+from luca_paciolai.models import Transaction
+
+
+def test_add_command_persists_transaction(monkeypatch):
+    runner = CliRunner()
+
+    parsed = {
+        "date": "2023-01-01",
+        "description": "Coffee",
+        "debit": "Expenses:Coffee",
+        "credit": "Assets:Cash",
+        "amount": 5.0,
+        "currency": "USD",
+    }
+
+    captured = {}
+
+    monkeypatch.setattr(cli, "create_session", lambda: SimpleNamespace())
+
+    def fake_add_transaction(session, tx):
+        captured["tx"] = tx
+
+    def fake_parse_transaction(text, accounts):
+        captured["text"] = text
+        return parsed
+
+    monkeypatch.setattr(cli, "add_transaction", fake_add_transaction)
+    monkeypatch.setattr(cli, "parse_transaction", fake_parse_transaction)
+    monkeypatch.setattr(cli, "load_selected_model", lambda: "model")
+
+    result = runner.invoke(cli.app, ["add", "I bought coffee for $5"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == parsed
+    assert captured["text"] == "I bought coffee for $5"
+    assert isinstance(captured["tx"], Transaction)
+    assert captured["tx"].amount == 5.0


### PR DESCRIPTION
## Summary
- add new test for the CLI `add` command

## Testing
- `uv run python -m pytest -q`
- `uvx ruff check luca_paciolai`
- `uv run mypy luca_paciolai` *(fails: Library stubs not installed for "requests")*


------
https://chatgpt.com/codex/tasks/task_e_6854f0633924832ba9b9e8424359e61c