### PR TITLE
Implement account context and update CLI

### DIFF
--- a/luca_paciolai/cli.py
+++ b/luca_paciolai/cli.py
@@ -7,7 +7,7 @@ __all__ = ["app", "main", "add", "select_model"]
 
 import typer
 
-from .ledger import create_session, add_transaction
+from .ledger import create_session, add_transaction, list_accounts
 from .llm import parse_transaction
 from .models import Transaction
 from .model_selection import (
@@ -23,10 +23,10 @@ app = typer.Typer()
 def add(text: str) -> None:
     """Parse natural language transaction and save to the ledger."""
     session = create_session()
-    # TODO: load existing accounts
+    accounts = list_accounts(session)
     _model = load_selected_model()
     # TODO: pass `_model` to the LLM API when implemented
-    result = parse_transaction(text, [])
+    result = parse_transaction(text, accounts)
     tx = Transaction(**result)
     add_transaction(session, tx)
     typer.echo(json.dumps(result, indent=2, default=str))

--- a/luca_paciolai/ledger.py
+++ b/luca_paciolai/ledger.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from sqlmodel import SQLModel, Session, create_engine
+from sqlmodel import SQLModel, Session, create_engine, select
 
 from .config import LEDGER_PATH
 
 from .models import Transaction
 
-__all__ = ["create_session", "init_db", "add_transaction"]
+__all__ = ["create_session", "init_db", "add_transaction", "list_accounts"]
 
 
 def create_session(db_url: str | None = None) -> Session:
@@ -27,4 +27,12 @@ def add_transaction(session: Session, tx: Transaction) -> None:
     """Persist a transaction to the ledger."""
     session.add(tx)  # type: ignore[arg-type]
     session.commit()
+
+
+def list_accounts(session: Session) -> list[str]:
+    """Return unique account names present in the ledger."""
+    debit_accounts = session.exec(select(Transaction.debit)).all()
+    credit_accounts = session.exec(select(Transaction.credit)).all()
+    accounts = set(debit_accounts + credit_accounts)
+    return sorted(a for a in accounts if a)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,15 +28,18 @@ def test_add_command_persists_transaction(monkeypatch):
 
     def fake_parse_transaction(text, accounts):
         captured["text"] = text
+        captured["accounts"] = accounts
         return parsed
 
     monkeypatch.setattr(cli, "add_transaction", fake_add_transaction)
     monkeypatch.setattr(cli, "parse_transaction", fake_parse_transaction)
     monkeypatch.setattr(cli, "load_selected_model", lambda: "model")
+    monkeypatch.setattr(cli, "list_accounts", lambda session: ["Assets:Cash"]) 
 
     result = runner.invoke(cli.app, ["add", "I bought coffee for $5"])
     assert result.exit_code == 0
     assert json.loads(result.stdout) == parsed
     assert captured["text"] == "I bought coffee for $5"
+    assert captured["accounts"] == ["Assets:Cash"]
     assert isinstance(captured["tx"], Transaction)
     assert captured["tx"].amount == 5.0

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,27 @@
+from datetime import date
+from luca_paciolai.ledger import create_session, add_transaction, list_accounts
+from luca_paciolai.models import Transaction
+
+
+def test_list_accounts_returns_unique_names():
+    session = create_session("sqlite:///:memory:")
+    tx1 = Transaction(
+        date=date.today(),
+        description="Coffee",
+        debit="Expenses:Coffee",
+        credit="Assets:Cash",
+        amount=5.0,
+        currency="USD",
+    )
+    tx2 = Transaction(
+        date=date.today(),
+        description="Salary",
+        debit="Assets:Cash",
+        credit="Income:Salary",
+        amount=100.0,
+        currency="USD",
+    )
+    add_transaction(session, tx1)
+    add_transaction(session, tx2)
+    accounts = list_accounts(session)
+    assert accounts == ["Assets:Cash", "Expenses:Coffee", "Income:Salary"]

--- a/tests/test_venice_client.py
+++ b/tests/test_venice_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from luca_paciolai import venice_client
 


### PR DESCRIPTION
## Summary
- load account names from the ledger
- include accounts when invoking `parse_transaction`
- test CLI account passing
- add ledger account listing tests
- remove unused imports in tests

## Testing
- `uvx ruff check luca_paciolai tests`
- `uv run python -m pytest -q`
- `uv run mypy luca_paciolai` *(fails: Library stubs not installed for "requests")*

------
https://chatgpt.com/codex/tasks/task_e_6854f6c57848832b9d15de1757ac542e