### PR TITLE
Update specchange: note account context support

### DIFF
--- a/agentinstructs/specchange.md
+++ b/agentinstructs/specchange.md
@@ -8,13 +8,14 @@ This document records variances between `SPEC.md` and the current codebase as of
 - Transactions are persisted to SQLite through SQLModel.
 - LLM parsing stub exists (`luca_paciolai.llm.parse_transaction`).
 - Venice model selection helpers (`model_selection.py`) allow choosing a reasoning-capable model.
+- `parse_transaction` now receives the list of existing accounts, providing
+  the LLM with account context.
+- The ledger creates missing accounts on demand using `ensure_accounts`.
 
 ## Missing or Incomplete Features
 
 The following areas of `SPEC.md` are not fully implemented:
 
-- **Account Context**: `parse_transaction` does not yet include the list of existing accounts when calling the LLM.
-- **Dynamic Chart of Accounts**: No module manages account creation or confirmation.
 - **Balance Enforcement**: Transactions are not checked to ensure debits equal credits.
 - **Tax Lot Tracking**: `TaxLot` model is defined but acquisition/sale logic and prompts are absent.
 - **Multi-Currency and Reporting**: Support for exchange rates and financial reports is not implemented.


### PR DESCRIPTION
## Summary
- document that parse_transaction now receives account names
- note automatic account creation
- remove outdated missing-feature entries

## Testing
- `uv run python -m pytest -q`
- `uvx ruff check luca_paciolai`
- `uv run mypy luca_paciolai` *(fails: Library stubs not installed for "requests")*

------
https://chatgpt.com/codex/tasks/task_e_6855c3778508832bbe02c4171ada73cd