### PR TITLE
Add CLI model selection test

### DIFF
--- a/tests/test_venice_client.py
+++ b/tests/test_venice_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from luca_paciolai import venice_client
 


### PR DESCRIPTION
## Summary
- expand CLI tests to verify select-model
- clean up unused imports in tests

## Testing
- `uvx ruff check luca_paciolai tests`
- `uv run mypy luca_paciolai` *(fails: Library stubs not installed for "requests")*
- `uv run python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c379dfcc832bb11e0aff4807c1f5