### PR TITLE
Add ascii notepad CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ dependencies.
 uv run main.py add "I bought coffee today for $6"
 ```
 
+You can also launch a small ASCII notepad interface:
+
+```bash
+uv run main.py notepad
+```
+
 Set the `OPENAI_API_KEY` environment variable before running commands. The
 parser sends statements to OpenAI's API.
 

--- a/luca_paciolai/cli.py
+++ b/luca_paciolai/cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 
-__all__ = ["app", "main", "add", "select_model"]
+__all__ = ["app", "main", "add", "select_model", "notepad"]
 
 import typer
 
@@ -55,6 +55,26 @@ def select_model() -> None:
     selected = models[choice - 1]["id"]
     save_selected_model(selected)
     typer.echo(f"Selected model: {selected}")
+
+
+@app.command()
+def notepad() -> None:
+    """Interactive ASCII notepad for entering transactions."""
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.shortcuts import print_formatted_text
+    from prompt_toolkit.styles import Style
+    from prompt_toolkit.formatted_text import HTML
+
+    header = HTML(
+        "<ansimagenta>*******************************\n"
+        "* OKDSKEWL PSYCHO ANSI NOTEPAD *\n"
+        "*******************************</ansimagenta>"
+    )
+    print_formatted_text(header)
+    style = Style.from_dict({"prompt": "ansiyellow"})
+    session = PromptSession("\n> ", multiline=True, style=style)
+    text = session.prompt()
+    add(text)
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "sqlmodel>=0.0.24",
     "typer>=0.16.0",
     "requests>=2.31.0",
+    "prompt-toolkit>=3.0.51",
 ]
 
 [dependency-groups]

--- a/tests/test_notepad.py
+++ b/tests/test_notepad.py
@@ -1,0 +1,21 @@
+from luca_paciolai import cli
+
+
+def test_notepad_calls_add(monkeypatch):
+    captured = {}
+
+    def fake_add(text: str) -> None:
+        captured['text'] = text
+
+    class FakeSession:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def prompt(self) -> str:  # type: ignore[override]
+            return "test tx"
+
+    monkeypatch.setattr(cli, "add", fake_add)
+    monkeypatch.setattr("prompt_toolkit.PromptSession", lambda *a, **k: FakeSession())
+    monkeypatch.setattr("prompt_toolkit.shortcuts.print_formatted_text", lambda *a, **k: None)
+    cli.notepad()
+    assert captured['text'] == "test tx"

--- a/uv.lock
+++ b/uv.lock
@@ -283,6 +283,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "openai" },
+    { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "sqlmodel" },
@@ -298,6 +299,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "openai", specifier = ">=1.88.0" },
+    { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "sqlmodel", specifier = ">=0.0.24" },
@@ -366,6 +368,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/6e/9d084c929dfe9e3bfe0c6a47e31f78a25c54627d64a66e884a8bf5474f1c/prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed", size = 428940, upload-time = "2025-04-15T09:18:47.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/4f/5249960887b1fbe561d9ff265496d170b55a735b76724f10ef19f9e40716/prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07", size = 387810, upload-time = "2025-04-15T09:18:44.753Z" },
 ]
 
 [[package]]
@@ -607,4 +621,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
 ]


### PR DESCRIPTION
## Summary
- add a new `notepad` command with an ANSI art header
- document the command in the README
- add `prompt-toolkit` dependency
- test that the command forwards user input to `add`

## Testing
- `uvx ruff check luca_paciolai tests`
- `uv run mypy luca_paciolai` *(fails: Library stubs not installed for "requests")*
- `uv run python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560e337070832b8466fdb8998b270b